### PR TITLE
Use SHA2 instead of SHA1

### DIFF
--- a/includes/functions.sh
+++ b/includes/functions.sh
@@ -207,7 +207,7 @@ DEBIAN_FRONTEND=noninteractive apt-get --force-yes -y install dovecot-common dov
 		ssl)
 			rm /etc/ssl/mail/* 2> /dev/null
 			mkdir /etc/ssl/mail
-			openssl req -new -newkey rsa:4096 -days 1095 -nodes -x509 -subj "/C=$cert_country/ST=$cert_state/L=$cert_city/O=$cert_org/CN=$sys_hostname.$sys_domain" -keyout /etc/ssl/mail/mail.key  -out /etc/ssl/mail/mail.crt
+			openssl req -new -newkey rsa:4096 -sha256 -days 1095 -nodes -x509 -subj "/C=$cert_country/ST=$cert_state/L=$cert_city/O=$cert_org/CN=$sys_hostname.$sys_domain" -keyout /etc/ssl/mail/mail.key  -out /etc/ssl/mail/mail.crt
 			chmod 600 /etc/ssl/mail/mail.key
 			cp /etc/ssl/mail/mail.crt /usr/local/share/ca-certificates/
 			update-ca-certificates

--- a/nginx/conf/sites-available/mail
+++ b/nginx/conf/sites-available/mail
@@ -26,6 +26,10 @@ server {
 	ssl_ciphers 'EDH+CAMELLIA:EDH+aRSA:EECDH+aRSA+AESGCM:EECDH+aRSA+SHA384:EECDH+aRSA+SHA256:EECDH:+CAMELLIA256:+AES256:+CAMELLIA128:+AES128:+SSLv3:!aNULL:!eNULL:!LOW:!3DES:!MD5:!EXP:!PSK:!DSS:!RC4:!SEED:!ECDSA:CAMELLIA256-SHA:AES256-SHA:CAMELLIA128-SHA:AES128-SHA';
 	add_header Strict-Transport-Security max-age=15768000;
 
+
+ssl_session_cache shared:SSL:5m;
+ssl_session_timeout 30m;
+
 	root /var/www/mail;
 	index index.html index.htm index.php;
 


### PR DESCRIPTION
OpenSSL sollte Zertifikate nur noch mit SHA2 erstellen, da SHA1 als unsicher angesehen wird.
Außerdem haben einige Browserhersteller angekündigt, künftig keine SHA1 Zertifikate mehr zu akzeptieren. 
(http://googleonlinesecurity.blogspot.de/2014/09/gradually-sunsetting-sha-1.html)

Auch sollte nginx die SSL-Session Cachen, um die Server-CPU nicht unnötig durch wiederholte SSL-Handshakes zu beschäftigen. 
Die 5MB Cache sollten für ca. 5.000 Verbindungen reichen
